### PR TITLE
Fix Interface Duplicates causing Crashes

### DIFF
--- a/Editors/BlueprintEditor/NodeWrangler/EntityNodeWrangler.cs
+++ b/Editors/BlueprintEditor/NodeWrangler/EntityNodeWrangler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -112,7 +112,8 @@ namespace BlueprintEditorPlugin.Editors.BlueprintEditor.NodeWrangler
                                 if (InterfaceEoCache.ContainsKey(HashingUtils.SmartHashString(interfaceNode.Header)))
                                 {
                                     App.Logger.LogError("Multiple copies of {0} interfaces exist!", interfaceNode.Header);
-                                }
+                                            return;
+                                        }
                                 InterfaceEoCache.Add(HashingUtils.SmartHashString(interfaceNode.Header), interfaceNode);
                             } break;
                             case ConnectionType.Link:
@@ -120,7 +121,8 @@ namespace BlueprintEditorPlugin.Editors.BlueprintEditor.NodeWrangler
                                 if (InterfaceLoCache.ContainsKey(HashingUtils.SmartHashString(interfaceNode.Header)))
                                 {
                                     App.Logger.LogError("Multiple copies of {0} interfaces exist!", interfaceNode.Header);
-                                }
+                                            return;
+                                        }
                                 InterfaceLoCache.Add(HashingUtils.SmartHashString(interfaceNode.Header), interfaceNode);
                             } break;
                             case ConnectionType.Property:
@@ -128,6 +130,7 @@ namespace BlueprintEditorPlugin.Editors.BlueprintEditor.NodeWrangler
                                 if (InterfacePoCache.ContainsKey(HashingUtils.SmartHashString(interfaceNode.Header)))
                                 {
                                     App.Logger.LogError("Multiple copies of {0} interfaces exist!", interfaceNode.Header);
+                                            return;
                                 }
                                 InterfacePoCache.Add(HashingUtils.SmartHashString(interfaceNode.Header), interfaceNode);
                             } break;


### PR DESCRIPTION
If an input or output field, event, or link is copied or defined more t than once then it would crash